### PR TITLE
Ops 5421 reportportal mcp server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,7 @@ FROM gcr.io/distroless/base-debian12
 WORKDIR /server
 # Copy the binary from the build stage
 COPY --from=build /build/reportportal-mcp-server .
-# Command to run the server
-CMD ["./reportportal-mcp-server"]
+# Expose MCP SSE port (informational)
+EXPOSE 4389
+# Default to SSE mode on port 4389
+CMD ["./reportportal-mcp-server", "sse", "--addr", ":4389"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to expose port 4389 and adjusted the server startup command to listen on this port in SSE mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->